### PR TITLE
:bug: 배포 서버에서 쿠키에 저장이 안되는 에러 해결 (#36)

### DIFF
--- a/src/main/java/com/tickettogether/global/config/security/jwt/JwtConfig.java
+++ b/src/main/java/com/tickettogether/global/config/security/jwt/JwtConfig.java
@@ -5,10 +5,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.core.userdetails.UserDetailsService;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -23,15 +19,15 @@ public class JwtConfig {
     private String refreshExpiry;
 
     @Value("${jwt.authorized-redirect-uris}")
-    private List<String> authorizedRedirectUris = new ArrayList<>();
+    private String authorizedRedirectUri;
 
     @Bean
     public AuthTokenProvider jwtProvider() {
         return new AuthTokenProvider(this.secret, this.tokenExpiry);
     }
 
-    public List<String> getAuthorizedRedirectUris() {
-        return authorizedRedirectUris;
+    public String getAuthorizedRedirectUri() {
+        return authorizedRedirectUri;
     }
 
     public String getRefreshExpiry() { return refreshExpiry;}

--- a/src/main/java/com/tickettogether/global/config/security/oauth/handler/MyOauth2FailureHandler.java
+++ b/src/main/java/com/tickettogether/global/config/security/oauth/handler/MyOauth2FailureHandler.java
@@ -1,19 +1,16 @@
 package com.tickettogether.global.config.security.oauth.handler;
 
+import com.tickettogether.global.config.security.jwt.JwtConfig;
 import com.tickettogether.global.config.security.oauth.repository.OAuth2AuthorizationRequestRepository;
-import com.tickettogether.global.config.security.utils.CookieUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.servlet.ServletException;
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-
-import static com.tickettogether.global.config.security.oauth.repository.OAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
 
 @RequiredArgsConstructor
 public class MyOauth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
@@ -21,10 +18,8 @@ public class MyOauth2FailureHandler extends SimpleUrlAuthenticationFailureHandle
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
-        String targetUrl = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
-                .map(Cookie::getValue)
-                .orElse(("/"));
-
+        JwtConfig jwtConfig = new JwtConfig();
+        String targetUrl = jwtConfig.getAuthorizedRedirectUri();
         exception.printStackTrace();
 
         targetUrl = UriComponentsBuilder.fromUriString(targetUrl)

--- a/src/main/java/com/tickettogether/global/config/security/oauth/repository/OAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/tickettogether/global/config/security/oauth/repository/OAuth2AuthorizationRequestRepository.java
@@ -11,7 +11,6 @@ import javax.servlet.http.HttpServletResponse;
 
 public class OAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository {
     public final static String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
-    public final static String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
     public final static String REFRESH_TOKEN_COOKIE_NAME = "refresh";
     private final static int cookieExpireSeconds = 180;
     private OAuth2AuthorizationRequest authorizationRequest;
@@ -34,10 +33,6 @@ public class OAuth2AuthorizationRequestRepository implements AuthorizationReques
         }
         this.authorizationRequest = authorizationRequest;
         CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
-        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
-        if (StringUtils.hasText(redirectUriAfterLogin)){
-            CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
-        }
     }
 
     @Override
@@ -52,6 +47,5 @@ public class OAuth2AuthorizationRequestRepository implements AuthorizationReques
 
     public void removeAuthorizationRequestCookie(HttpServletRequest request, HttpServletResponse response){
         CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
-        CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
     }
 }


### PR DESCRIPTION
## ☁️ 개요
- 로컬에서는 쿠키에 redirect 주소 정보가 저장이 되지만, 배포 서버에서는 저장이 되지 않음

## ✏️ 작업 내용
- 쿠키에 저장하지 않고 바로 설정 파일에서 주소를 가져오도록 변경했습니다:)

## 🔎 추가 정보 
- 이슈 번호, 추가 정보를 작성해 주세요.
- #36 