### PR TITLE
:sparkles: Keyword 적용 방식 수정 (#66)

### DIFF
--- a/src/main/java/com/tickettogether/domain/member/domain/Keyword.java
+++ b/src/main/java/com/tickettogether/domain/member/domain/Keyword.java
@@ -1,26 +1,6 @@
 package com.tickettogether.domain.member.domain;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
-import java.util.List;
-
-@Entity
-@Getter
-@NoArgsConstructor
-public class Keyword {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="keyword_id")
-    private Long id;
-
-    private String name;
-
-    @OneToMany(mappedBy = "keyword", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<MemberKeyword> memberKeyword;
-
-    public Keyword(String name){
-        this.name = name;
-    }
+public enum Keyword {
+    CONCERT, CLASSIC
+    //TODO 영현언니 담당 크롤링 목록 추가
 }

--- a/src/main/java/com/tickettogether/domain/member/domain/Keyword.java
+++ b/src/main/java/com/tickettogether/domain/member/domain/Keyword.java
@@ -1,6 +1,0 @@
-package com.tickettogether.domain.member.domain;
-
-public enum Keyword {
-    CONCERT, CLASSIC
-    //TODO 영현언니 담당 크롤링 목록 추가
-}

--- a/src/main/java/com/tickettogether/domain/member/domain/Member.java
+++ b/src/main/java/com/tickettogether/domain/member/domain/Member.java
@@ -26,13 +26,14 @@ public class Member extends BaseEntity {
     private List<MemberParts> memberPartsList = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<MemberKeyword> keywords = new ArrayList<>();
-
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TicketSiteInfo> siteInfos = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Review> reviews = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemberKeyword> memberKeywords = new ArrayList<>();
+
     private String phoneNumber;
 
     @Column(nullable = false)

--- a/src/main/java/com/tickettogether/domain/member/domain/MemberKeyword.java
+++ b/src/main/java/com/tickettogether/domain/member/domain/MemberKeyword.java
@@ -1,28 +1,24 @@
 package com.tickettogether.domain.member.domain;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 
+@Getter
 @Entity
-@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Builder
 public class MemberKeyword {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="member_keyword_id")
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_keyword_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @ManyToOne
+    @JoinColumn(name="member_id")
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="keyword_id")
+    @Enumerated(EnumType.STRING)
     private Keyword keyword;
 }

--- a/src/main/java/com/tickettogether/domain/member/domain/MemberKeyword.java
+++ b/src/main/java/com/tickettogether/domain/member/domain/MemberKeyword.java
@@ -1,5 +1,7 @@
 package com.tickettogether.domain.member.domain;
 
+import com.tickettogether.domain.culture.domain.Culture;
+import com.tickettogether.domain.culture.domain.CultureKeyword;
 import lombok.*;
 
 import javax.persistence.*;
@@ -20,5 +22,5 @@ public class MemberKeyword {
     private Member member;
 
     @Enumerated(EnumType.STRING)
-    private Keyword keyword;
+    private CultureKeyword keyword;
 }

--- a/src/main/java/com/tickettogether/domain/member/dto/MemberDto.java
+++ b/src/main/java/com/tickettogether/domain/member/dto/MemberDto.java
@@ -13,7 +13,7 @@ public class MemberDto {
     @AllArgsConstructor
     public static class SaveRequest{
         private String phoneNumber;
-        private List<Long> keywordIds;
+        private List<String> keywords;
     }
 
     @Getter
@@ -48,5 +48,6 @@ public class MemberDto {
         private String email;
         private String imgUrl;
         private String phoneNumber;
+        private List<String> keywords;
     }
 }

--- a/src/main/java/com/tickettogether/domain/member/repository/KeywordRepository.java
+++ b/src/main/java/com/tickettogether/domain/member/repository/KeywordRepository.java
@@ -1,8 +1,0 @@
-package com.tickettogether.domain.member.repository;
-
-import com.tickettogether.domain.member.domain.Keyword;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface KeywordRepository extends JpaRepository<Keyword, Long> {
-
-}

--- a/src/main/java/com/tickettogether/domain/member/repository/MemberKeywordRepository.java
+++ b/src/main/java/com/tickettogether/domain/member/repository/MemberKeywordRepository.java
@@ -1,7 +1,14 @@
 package com.tickettogether.domain.member.repository;
 
+import com.tickettogether.domain.member.domain.Member;
 import com.tickettogether.domain.member.domain.MemberKeyword;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface MemberKeywordRepository extends JpaRepository<MemberKeyword, Long> {
+
+    List<MemberKeyword> findAllByMember(Member member);
 }

--- a/src/main/java/com/tickettogether/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/tickettogether/domain/member/service/MemberServiceImpl.java
@@ -1,6 +1,6 @@
 package com.tickettogether.domain.member.service;
 
-import com.tickettogether.domain.member.domain.Keyword;
+import com.tickettogether.domain.culture.domain.CultureKeyword;
 import com.tickettogether.domain.member.domain.Member;
 import com.tickettogether.domain.member.domain.MemberKeyword;
 import com.tickettogether.domain.member.dto.MemberDto;
@@ -11,9 +11,7 @@ import com.tickettogether.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.yaml.snakeyaml.util.EnumUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,7 +31,7 @@ public class MemberServiceImpl implements MemberService{
 
         for(String k : saveRequest.getKeywords()){
             try{
-                Keyword keyword = Keyword.valueOf(k);
+                CultureKeyword keyword = CultureKeyword.valueOf(k);
                 memberKeywordRepository.save(
                         MemberKeyword.builder()
                                 .member(member)


### PR DESCRIPTION
## ☁️ 개요
- 키워드 타입 변경했습니다

## ✏️ 작업 내용
- `엔티티` => `Enum`
- 멤버 정보 반환 필드에 키워드를 깜빡하고 안했더라구요!! 추가했습니다

## 🔎 추가 정보
- 이슈 번호, 추가 정보를 작성해 주세요.
- #66 