### PR TITLE
:bug: 소셜 로그인 유저 저장 에러 (#73)

### DIFF
--- a/src/main/java/com/tickettogether/global/config/security/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/tickettogether/global/config/security/oauth/service/CustomOAuth2UserService.java
@@ -52,7 +52,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     }
 
     private Member saveOrUpdateMemberToDB(OAuthAttributes attrs){
-        Member member = memberRepository.findByEmail(attrs.getEmail()).orElseThrow(UserEmptyException::new);
+        Member member = memberRepository.findByEmail(attrs.getEmail()).orElse(null);
         if (Optional.ofNullable(member).isEmpty()){
             return memberRepository.save(attrs.toEntity());
         }


### PR DESCRIPTION
## ☁️ 개요
- 프론트엔드하고 연동하다가 로그인 시 저장이 안되는 에러가 나서 수정했습니다:)

## ✏️ 작업 내용
- `UserNotFoundexception`을 잘못 발생시켜서 고쳤습니다!

## 🔎 추가 정보
#73 
- 이슈 번호, 추가 정보를 작성해 주세요.