### PR TITLE
:bug: JWT 프로퍼티 바인딩 에러 재해결

### DIFF
--- a/src/main/java/com/tickettogether/global/config/security/jwt/JwtConfig.java
+++ b/src/main/java/com/tickettogether/global/config/security/jwt/JwtConfig.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @RequiredArgsConstructor
 public class JwtConfig {
-    @Value("${jwt.secret}")
+    @Value("${jwt.secret:}")
     private String secret;
 
     @Value("${jwt.token-expiry}")


### PR DESCRIPTION
## ☁️ 개요
- JWT 설정 파일 값 바인딩 되지 않는 에러가 자꾸 나서 고치고 디벨롭으로 올려봅니당..

## ✏️ 작업 내용
- 프로퍼티 디폴트 값 추가

## 🔎 추가 정보
- 이슈 번호, 추가 정보를 작성해 주세요.
- #17 