### PR TITLE
♻️ 메시지를 읽는 소켓 작업과 저장하는 I/O 작업 분리

### DIFF
--- a/src/main/java/com/tickettogether/domain/chat/controller/StompChatController.java
+++ b/src/main/java/com/tickettogether/domain/chat/controller/StompChatController.java
@@ -1,6 +1,7 @@
 package com.tickettogether.domain.chat.controller;
 
 import com.tickettogether.domain.chat.service.ChatRoomServiceImpl;
+import com.tickettogether.global.common.Constant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -24,8 +25,6 @@ public class StompChatController {
     
     private final ChatRoomServiceImpl chatRoomService;
 
-    private static final String CHAT_QUEUE_NAME = "chat.queue";
-
     @MessageMapping("chat.enter.{roomId}")
     @SendTo("/topic/room.{roomId}")
     public ChatMessageResponse enter(@Payload ChatStompRequest message, @DestinationVariable String roomId, SimpMessageHeaderAccessor headerAccessor){
@@ -33,7 +32,7 @@ public class StompChatController {
         Objects.requireNonNull(headerAccessor.getSessionAttributes()).put("roomId", roomId);
 
         ChatMessageResponse sendMessage = chatRoomService.createChatMessageOrSave(message, Long.parseLong(roomId));
-        rabbitTemplate.convertAndSend(CHAT_QUEUE_NAME, sendMessage);
+        rabbitTemplate.convertAndSend(Constant.CHAT_QUEUE_NAME, sendMessage);
         return sendMessage;
     }
 
@@ -41,7 +40,7 @@ public class StompChatController {
     @SendTo("/topic/room.{roomId}")
     public ChatMessageResponse message(@Payload ChatStompRequest message, @DestinationVariable String roomId){
         ChatMessageResponse sendMessage = chatRoomService.createChatMessageOrSave(message, Long.parseLong(roomId));
-        rabbitTemplate.convertAndSend(CHAT_QUEUE_NAME, sendMessage);
+        rabbitTemplate.convertAndSend(Constant.CHAT_QUEUE_NAME, sendMessage);
         return sendMessage;
     }
 }

--- a/src/main/java/com/tickettogether/domain/chat/controller/StompChatController.java
+++ b/src/main/java/com/tickettogether/domain/chat/controller/StompChatController.java
@@ -1,6 +1,5 @@
 package com.tickettogether.domain.chat.controller;
 
-import com.tickettogether.domain.chat.service.ChatRoomServiceImpl;
 import com.tickettogether.global.common.Constant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,7 +12,6 @@ import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Controller;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
 import static com.tickettogether.domain.chat.dto.ChatDto.*;

--- a/src/main/java/com/tickettogether/domain/chat/controller/StompChatController.java
+++ b/src/main/java/com/tickettogether/domain/chat/controller/StompChatController.java
@@ -12,6 +12,8 @@ import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Controller;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
 import static com.tickettogether.domain.chat.dto.ChatDto.*;
@@ -22,8 +24,6 @@ import static com.tickettogether.domain.chat.dto.ChatDto.*;
 public class StompChatController {
 
     private final RabbitTemplate rabbitTemplate;
-    
-    private final ChatRoomServiceImpl chatRoomService;
 
     @MessageMapping("chat.enter.{roomId}")
     @SendTo("/topic/room.{roomId}")
@@ -31,16 +31,17 @@ public class StompChatController {
         Objects.requireNonNull(headerAccessor.getSessionAttributes()).put("username", message.getSender());
         Objects.requireNonNull(headerAccessor.getSessionAttributes()).put("roomId", roomId);
 
-        ChatMessageResponse sendMessage = chatRoomService.createChatMessageOrSave(message, Long.parseLong(roomId));
-        rabbitTemplate.convertAndSend(Constant.CHAT_QUEUE_NAME, sendMessage);
-        return sendMessage;
+        ChatMessageResponse sendEnterMessage = ChatMessageResponse.create(message, Long.parseLong(roomId));
+        sendEnterMessage.setData(message.getSender() + "님이 들어왔습니다.");
+        rabbitTemplate.convertAndSend(Constant.CHAT_QUEUE_NAME, sendEnterMessage);
+        return sendEnterMessage;
     }
 
     @MessageMapping("chat.message.{roomId}")
     @SendTo("/topic/room.{roomId}")
     public ChatMessageResponse message(@Payload ChatStompRequest message, @DestinationVariable String roomId){
-        ChatMessageResponse sendMessage = chatRoomService.createChatMessageOrSave(message, Long.parseLong(roomId));
-        rabbitTemplate.convertAndSend(Constant.CHAT_QUEUE_NAME, sendMessage);
-        return sendMessage;
+        ChatMessageResponse sendChatMessage = ChatMessageResponse.create(message, Long.parseLong(roomId), LocalDateTime.now());
+        rabbitTemplate.convertAndSend(Constant.CHAT_QUEUE_NAME, sendChatMessage);
+        return sendChatMessage;
     }
 }

--- a/src/main/java/com/tickettogether/domain/chat/domain/ChatMessage.java
+++ b/src/main/java/com/tickettogether/domain/chat/domain/ChatMessage.java
@@ -1,15 +1,15 @@
 package com.tickettogether.domain.chat.domain;
 
-import com.tickettogether.global.entity.BaseEntity;
 import lombok.*;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class ChatMessage extends BaseEntity {
+public class ChatMessage {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "message_id")
@@ -26,6 +26,8 @@ public class ChatMessage extends BaseEntity {
 
     private String data;
 
+    private LocalDateTime createdAt;
+
     public enum MessageType{
         CHAT,
         JOIN,
@@ -33,10 +35,11 @@ public class ChatMessage extends BaseEntity {
     }
 
     @Builder
-    public ChatMessage(ChatRoom chatRoom, MessageType type, String sender, String data){
+    public ChatMessage(ChatRoom chatRoom, MessageType type, String sender, String data, LocalDateTime createdAt){
         this.chatRoom = chatRoom;
         this.type = type;
         this.sender = sender;
         this.data = data;
+        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/com/tickettogether/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/com/tickettogether/domain/chat/domain/ChatRoom.java
@@ -23,7 +23,7 @@ public class ChatRoom {
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatMessage> chatMessageList = new ArrayList<>();
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parts_id")
     private Parts parts;
 

--- a/src/main/java/com/tickettogether/domain/chat/dto/ChatDto.java
+++ b/src/main/java/com/tickettogether/domain/chat/dto/ChatDto.java
@@ -2,8 +2,15 @@ package com.tickettogether.domain.chat.dto;
 
 import com.tickettogether.domain.chat.domain.ChatMessage;
 import com.tickettogether.domain.chat.domain.ChatRoom;
+import com.tickettogether.global.common.Constant;
 import com.tickettogether.global.dto.PageDto;
 import lombok.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static com.tickettogether.domain.chat.domain.ChatMessage.*;
+import static com.tickettogether.global.common.Constant.*;
 
 
 @Getter
@@ -32,13 +39,47 @@ public class ChatDto {
     @AllArgsConstructor
     @Builder
     public static class ChatMessageResponse{
+        private Long roomId;
         private String sender;
         private String data;
         private String createdAt;
         private String type;
 
+        public static ChatMessageResponse create(ChatMessage x){
+            return chatMessageResponseBuilder(null, x.getSender(), x.getData(), x.getType().toString(), x.getCreatedAt());
+        }
+
+        public static ChatMessageResponse create(ChatStompRequest x, Long roomId){
+            return chatMessageResponseBuilder(roomId, x.getSender(), x.getData(), x.getType(), null);
+        }
+        public static ChatMessageResponse create(ChatStompRequest x, Long roomId, LocalDateTime createdAt){
+            return chatMessageResponseBuilder(roomId, x.getSender(), x.getData(), x.getType(), createdAt);
+        }
+
         public void setData(String data){
             this.data = data;
+        }
+
+        public ChatMessage toEntity(ChatRoom chatRoom){
+            return ChatMessage.builder()
+                    .sender(sender)
+                    .type(MessageType.valueOf(MessageType.class, type))
+                    .data(data)
+                    .chatRoom(chatRoom)
+                    .createdAt(LocalDateTime.parse(createdAt, DateTimeFormatter.ofPattern(DATETIME_FORMAT_PATTERN)))
+                    .build();
+        }
+
+        private static ChatMessageResponse chatMessageResponseBuilder(Long roomId, String sender, String data, String type, LocalDateTime time){
+            String createdAt = null;
+            if (time != null) createdAt = time.format(DateTimeFormatter.ofPattern(DATETIME_FORMAT_PATTERN));
+
+            return ChatDto.ChatMessageResponse.builder()
+                    .roomId(roomId)
+                    .sender(sender)
+                    .data(data)
+                    .type(type)
+                    .createdAt(createdAt).build();
         }
     }
 
@@ -61,9 +102,9 @@ public class ChatDto {
         private String type;
 
         public ChatMessage toEntity(ChatRoom chatRoom){
-            return ChatMessage.builder()
+            return builder()
                     .sender(sender)
-                    .type(ChatMessage.MessageType.valueOf(type))
+                    .type(MessageType.valueOf(type))
                     .data(data)
                     .chatRoom(chatRoom)
                     .build();

--- a/src/main/java/com/tickettogether/domain/chat/dto/ChatDto.java
+++ b/src/main/java/com/tickettogether/domain/chat/dto/ChatDto.java
@@ -2,7 +2,6 @@ package com.tickettogether.domain.chat.dto;
 
 import com.tickettogether.domain.chat.domain.ChatMessage;
 import com.tickettogether.domain.chat.domain.ChatRoom;
-import com.tickettogether.global.common.Constant;
 import com.tickettogether.global.dto.PageDto;
 import lombok.*;
 

--- a/src/main/java/com/tickettogether/domain/chat/listener/ChatMessageListener.java
+++ b/src/main/java/com/tickettogether/domain/chat/listener/ChatMessageListener.java
@@ -1,0 +1,26 @@
+package com.tickettogether.domain.chat.listener;
+
+import com.tickettogether.domain.chat.dto.ChatDto;
+import com.tickettogether.domain.chat.service.ChatRoomServiceImpl;
+import com.tickettogether.global.common.Constant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+import static com.tickettogether.domain.chat.domain.ChatMessage.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatMessageListener {
+
+    private final ChatRoomServiceImpl chatRoomService;
+
+    @RabbitListener(queues = Constant.CHAT_QUEUE_NAME)
+    public void receiveMessage(ChatDto.ChatMessageResponse chatMessage){
+        if (MessageType.CHAT.name().equals(chatMessage.getType())){
+            chatRoomService.saveChatMessage(chatMessage);
+        }
+    }
+}

--- a/src/main/java/com/tickettogether/domain/chat/listener/WebSocketEventListener.java
+++ b/src/main/java/com/tickettogether/domain/chat/listener/WebSocketEventListener.java
@@ -46,7 +46,7 @@ public class WebSocketEventListener {
 
             ChatMessageResponse disconnectMessage = ChatMessageResponse.builder()
                     .type(MessageType.LEAVE.name())
-                    .data(username + "님이 채팅방에서 나가셨습니다.")
+                    .data(username + "님이 나갔습니다.")
                     .sender(username).build();
 
             rabbitTemplate.convertAndSend("amq.topic", "room." + roomId , disconnectMessage);

--- a/src/main/java/com/tickettogether/domain/chat/listener/WebSocketEventListener.java
+++ b/src/main/java/com/tickettogether/domain/chat/listener/WebSocketEventListener.java
@@ -1,12 +1,10 @@
 package com.tickettogether.domain.chat.listener;
 
-import com.tickettogether.domain.chat.domain.ChatMessage;
-import com.tickettogether.domain.chat.dto.ChatDto;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.context.event.EventListener;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;

--- a/src/main/java/com/tickettogether/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/tickettogether/domain/chat/service/ChatRoomService.java
@@ -7,6 +7,6 @@ import org.springframework.data.domain.Pageable;
 public interface ChatRoomService {
 
     ChatEnterResponse createChatRoom(ChatDto.ChatEnterRequest request);
-    ChatDto.ChatMessageResponse createChatMessageOrSave(ChatDto.ChatStompRequest request, Long roomId);
     ChatDto.ChatSearchResponse getChatListByRoomId(Long roomId, Pageable pageable);
+    void saveChatMessage(ChatDto.ChatMessageResponse chatMessage);
 }

--- a/src/main/java/com/tickettogether/global/common/Constant.java
+++ b/src/main/java/com/tickettogether/global/common/Constant.java
@@ -10,4 +10,6 @@ public class Constant {
     public static final String CHAT_EXCHANGE_NAME = "chat.exchange";
 
     public static final String ROUTING_KEY = "room.*";
+
+    public static final String DATETIME_FORMAT_PATTERN = "yyyy-MM-dd HH:mm:ss";
 }

--- a/src/main/java/com/tickettogether/global/common/Constant.java
+++ b/src/main/java/com/tickettogether/global/common/Constant.java
@@ -3,4 +3,11 @@ package com.tickettogether.global.common;
 // 프로젝트에서 공통적으로 사용하는 상수들
 public class Constant {
     public static final String CATEGORY_CALENDAR = "calendar";
+
+    // RabbitMQ
+    public static final String CHAT_QUEUE_NAME = "chat.queue";
+
+    public static final String CHAT_EXCHANGE_NAME = "chat.exchange";
+
+    public static final String ROUTING_KEY = "room.*";
 }

--- a/src/main/java/com/tickettogether/global/config/rabbitmq/RabbitConfig.java
+++ b/src/main/java/com/tickettogether/global/config/rabbitmq/RabbitConfig.java
@@ -1,6 +1,7 @@
 package com.tickettogether.global.config.rabbitmq;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tickettogether.global.common.Constant;
 import org.springframework.amqp.core.*;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
@@ -15,10 +16,6 @@ import org.springframework.context.annotation.Configuration;
 @EnableRabbit
 public class RabbitConfig {
 
-    private static final String CHAT_QUEUE_NAME = "chat.queue";
-    private static final String CHAT_EXCHANGE_NAME = "chat.exchange";
-    private static final String ROUTING_KEY = "room.*";
-
     @Value("${spring.rabbitmq.host}")
     private String host;
 
@@ -30,24 +27,24 @@ public class RabbitConfig {
 
     @Bean
     public Queue Queue(){
-        return new Queue(CHAT_QUEUE_NAME, true);
+        return new Queue(Constant.CHAT_QUEUE_NAME, true);
     }
 
     @Bean
     public TopicExchange exchange(){
-        return new TopicExchange(CHAT_EXCHANGE_NAME);
+        return new TopicExchange(Constant.CHAT_EXCHANGE_NAME);
     }
 
     @Bean
     public Binding binding(Queue queue, TopicExchange exchange){
-        return BindingBuilder.bind(queue).to(exchange).with(ROUTING_KEY);
+        return BindingBuilder.bind(queue).to(exchange).with(Constant.ROUTING_KEY);
     }
 
     @Bean
     public RabbitTemplate rabbitTemplate(){
         RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory());
         rabbitTemplate.setMessageConverter(jsonMessageConverter());   // json 형식 지원
-        rabbitTemplate.setRoutingKey(ROUTING_KEY);
+        rabbitTemplate.setRoutingKey(Constant.ROUTING_KEY);
         return rabbitTemplate;
     }
 


### PR DESCRIPTION
## ☁️ 개요
- 메시지를 먼저 DB에 저장하고 사용자에게 응답하는 방식은 너무 느려서, 둘을 분리하였습니당

## ✏️ 작업 내용
- 공통 상수들 Constant 클래스로 이동
- RabbitListener 추가
- ChatDto 정적 팩토리 메소드로 리팩토링(DTO 생성하는 코드가 너무 중구난방으로 퍼지게 될것 같아서 수정했습니다)
- ChatMessage가 BaseEntity를 상속하게 되면 메시지를 발행할 때 시간이랑 저장 시간이랑 차이가 나기도 하고 여러가지 이유땜에!! 자동이 아닌 직접 생성 시간을 저장하는 걸로 바꿨습니다

## 🔎 추가 정보
- #105 