### PR TITLE
:recycle: 입장 시각 이후의 채팅 목록만 보여주도록 변경

### DIFF
--- a/src/main/java/com/tickettogether/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/tickettogether/domain/chat/controller/ChatRoomController.java
@@ -27,15 +27,17 @@ public class ChatRoomController {
         return ResponseEntity.ok(BaseResponse.create(ChatResponseMessage.ENTER_CHATROOM_SUCCESS.getMessage(), chatRoomService.createChatRoom(request)));
     }
 
-    @GetMapping("/{roomId}")
-    public ResponseEntity<BaseResponse<ChatDto.ChatSearchResponse>> getChatRoom(@PathVariable("roomId") Long roomId, @PageableDefault(size = 10) Pageable pageable) {
-        return ResponseEntity.ok(BaseResponse.create(ChatResponseMessage.GET_CHATROOM_SUCCESS.getMessage(), chatRoomService.getChatListByRoomId(roomId, pageable)));
+    @GetMapping("/{roomId}/{username}")
+    public ResponseEntity<BaseResponse<ChatDto.ChatSearchResponse>> getChatRoom(@PathVariable("roomId") Long roomId,
+                                                                                @PathVariable("username") String username, @PageableDefault(size = 10) Pageable pageable) {
+        return ResponseEntity.ok(BaseResponse.create(ChatResponseMessage.GET_CHATROOM_SUCCESS.getMessage(), chatRoomService.getChatListByRoomId(roomId, username, pageable)));
     }
 
-    @GetMapping("/{roomId}/test")    // STOMP 테스트용
-    public String getChatRoom(@PathVariable("roomId") Long roomId, Model model){
+    @GetMapping("/{roomId}/test/{username}")    // STOMP 테스트용
+    public String getChatRoom(@PathVariable("roomId") Long roomId, @PathVariable("username") String name, Model model){
         ChatRoom chatRoom = chatRoomRepository.getById(roomId);
         model.addAttribute("room", chatRoom);
+        model.addAttribute("user", name);
         return "Room";
     }
 }

--- a/src/main/java/com/tickettogether/domain/chat/dto/ChatDto.java
+++ b/src/main/java/com/tickettogether/domain/chat/dto/ChatDto.java
@@ -90,6 +90,13 @@ public class ChatDto {
         private Long roomId;
         private String roomName;
         private PageDto<ChatMessageResponse> messageList;
+
+        public static ChatSearchResponse create(Long roomId, String roomName, PageDto<ChatMessageResponse> messageList){
+            return ChatDto.ChatSearchResponse.builder()
+                    .roomId(roomId)
+                    .roomName(roomName)
+                    .messageList(messageList).build();
+        }
     }
 
     @Getter

--- a/src/main/java/com/tickettogether/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/tickettogether/domain/chat/repository/ChatMessageRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-    Page<ChatMessage> findAllByChatRoomOrderByCreatedAtDesc(Pageable pageable, ChatRoom chatRoom);
+    Page<ChatMessage> findAllByChatRoomAndCreatedAtGreaterThanEqualOrderByCreatedAt(Pageable pageable, ChatRoom chatRoom, LocalDateTime createdAt);
 }

--- a/src/main/java/com/tickettogether/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/tickettogether/domain/chat/service/ChatRoomService.java
@@ -7,6 +7,6 @@ import org.springframework.data.domain.Pageable;
 public interface ChatRoomService {
 
     ChatEnterResponse createChatRoom(ChatDto.ChatEnterRequest request);
-    ChatDto.ChatSearchResponse getChatListByRoomId(Long roomId, Pageable pageable);
+    ChatDto.ChatSearchResponse getChatListByRoomId(Long roomId, String username, Pageable pageable);
     void saveChatMessage(ChatDto.ChatMessageResponse chatMessage);
 }

--- a/src/main/java/com/tickettogether/global/config/redis/util/RedisUtil.java
+++ b/src/main/java/com/tickettogether/global/config/redis/util/RedisUtil.java
@@ -2,6 +2,7 @@ package com.tickettogether.global.config.redis.util;
 
 import com.tickettogether.global.config.security.jwt.JwtConfig;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -9,6 +10,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -29,6 +32,11 @@ public class RedisUtil<K, V> {
         redisTemplate.expire(key, Long.parseLong(jwtConfig.getRefreshExpiry()), TimeUnit.MILLISECONDS);
     }
 
+    public void setValue(K key, K hashKey, V value){
+        HashOperations<K, Object, Object> hashOperations = redisTemplate.opsForHash();
+        hashOperations.put(key, hashKey, value);
+    }
+
     public void setValueBlackList(K key, V value, Long milliSeconds){
         redisBlackListTemplate.opsForValue().set(key, value, milliSeconds, TimeUnit.MILLISECONDS);
     }
@@ -41,6 +49,18 @@ public class RedisUtil<K, V> {
     public List<V> getValues(K key){
         ListOperations<K, V> values = redisTemplate.opsForList();
         return values.range(key, 0, 1);
+    }
+
+    @SuppressWarnings(value = "unchecked")
+    public V getHashValue(K key, K hashKey){
+        HashOperations<K, Object, Object> values = redisTemplate.opsForHash();
+        return (V) values.get(key, hashKey);
+    }
+
+    @SuppressWarnings(value = "unchecked")
+    public Map<K, V> getHashKeys(K key){
+        HashOperations<K, Object, Object> values = redisTemplate.opsForHash();
+        return (Map<K, V>) values.entries(key);
     }
 
     public void deleteValue(K key){

--- a/src/main/resources/templates/Room.html
+++ b/src/main/resources/templates/Room.html
@@ -11,7 +11,7 @@
 
         var roomName = [[${room.name}]];
         var roomId = [[${room.id}]];
-        var username = "semi";
+        var username = [[${user}]];
 
         console.log(roomName + ", " + roomId + ", " + username);
 
@@ -39,14 +39,38 @@
                 }else{
                     str = "<div class='col-6'>";
                     str += "<div class='alert alert-warning'>";
-                    str += "<b>" + writer + " : " + message + "</b>";
+                    str += "<sb>" + writer + " : " + message + "</sb>";
                     str += "</div></div>";
                     $("#msgArea").append(str);
                 }
             });
 
-            //3. send(path, header, message)로 메세지를 보낼 수 있음
-            stomp.send('/pub/chat.enter.' + roomId, {}, JSON.stringify({type:"JOIN", sender: username}))
+            $.ajax({
+                url : "/api/v1/chat/1/" + username,
+                type : "get",
+                dataType : "json",
+                success: function(response) {
+                    var temp = JSON.stringify(response.result.messageList);
+                    var content = JSON.parse(temp);
+                    var t = content.contents;
+                    var str1 = '';
+                    if(t.length === 0){
+                        stomp.send('/pub/chat.enter.' + roomId, {}, JSON.stringify({type:"JOIN", sender: username}));
+                    }else{
+                        for(var i = 0; i <= t.length ; i++){
+                            var a = JSON.parse(JSON.stringify(t[i]));
+                            str1 = "<div class='col-6'>";
+                            str1 += "<div class='alert alert-secondary'>";
+                            str1 += "<b>" + a.sender + " : " + a.data + "</b>";
+                            str1 += "</div></div>";
+                            $("#msgArea").append(str1);
+                        }
+                    }
+                },
+                error: function(xhr) {
+                    console.log("[requestPostBodyJson] : [error] : " + JSON.stringify(xhr));
+                }
+            })
         });
 
         $("#button-send").on("click", function(e){


### PR DESCRIPTION
## ☁️ 개요
- 자신이 입장한 시각 이후의 채팅 목록을 재접속시 가져오도록 수정했습니다

## ✏️ 작업 내용
- 현재 채팅방에 참여하고 있는 유저 목록 Redis Hash로 관리
- 채팅 리스트 가져올때 createAt 내림차순에서 오름차순으로 변경
- 참고로 채팅 컨트롤러 경로에 username 추가한 것은 다른 유저들이 접속했을때의 테스트를 위해 바꿨습니다! 나중에 로그인 연동하고 나면은 다시 변경하도록 할게욥

## 🔎 추가 정보
- #108 