### PR TITLE
:zap: ChatMessage 시간 필드에 인덱스 적용

### DIFF
--- a/src/main/java/com/tickettogether/domain/chat/domain/ChatMessage.java
+++ b/src/main/java/com/tickettogether/domain/chat/domain/ChatMessage.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(indexes = @Index(name = "time", columnList = "createdAt"))
 public class ChatMessage {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/tickettogether/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/tickettogether/domain/chat/repository/ChatMessageRepository.java
@@ -2,12 +2,11 @@ package com.tickettogether.domain.chat.repository;
 
 import com.tickettogether.domain.chat.domain.ChatMessage;
 import com.tickettogether.domain.chat.domain.ChatRoom;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.time.LocalDateTime;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-    Page<ChatMessage> findAllByChatRoomAndCreatedAtGreaterThanEqualOrderByCreatedAt(Pageable pageable, ChatRoom chatRoom, LocalDateTime createdAt);
+    Slice<ChatMessage> findAllByChatRoomAndCreatedAtGreaterThanEqualOrderByCreatedAt(Pageable pageable, ChatRoom chatRoom, LocalDateTime createdAt);
 }

--- a/src/main/java/com/tickettogether/global/common/Constant.java
+++ b/src/main/java/com/tickettogether/global/common/Constant.java
@@ -11,5 +11,5 @@ public class Constant {
 
     public static final String ROUTING_KEY = "room.*";
 
-    public static final String DATETIME_FORMAT_PATTERN = "yyyy-MM-dd HH:mm:ss";
+    public static final String DATETIME_FORMAT_PATTERN = "yyyy-MM-dd HH:mm:ss:SSS";
 }

--- a/src/main/java/com/tickettogether/global/dto/PageDto.java
+++ b/src/main/java/com/tickettogether/global/dto/PageDto.java
@@ -3,7 +3,7 @@ package com.tickettogether.global.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 import lombok.experimental.Accessors;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 
 import java.util.List;
@@ -15,8 +15,6 @@ import java.util.List;
 public class PageDto<T> {
 
     private int pageNumber;
-
-    private int contentsCount;
 
     @JsonProperty("isFirst")
     private boolean first;
@@ -35,10 +33,9 @@ public class PageDto<T> {
 
     private List<T> contents;
 
-    public static <T> PageDto<T> create(Page<T> page, List<T> contents) {
+    public static <T> PageDto<T> create(Slice<T> page, List<T> contents) {
         return PageDto.<T>builder()
                 .pageNumber(page.getNumber() + 1)
-                .contentsCount(page.getContent().size())
                 .first(page.isFirst())
                 .last(page.isLast())
                 .hasNext(page.hasNext())


### PR DESCRIPTION
## ☁️ 개요
- 인덱스 적용해봤습니당

## ✏️ 작업 내용
- Page로 하니까 불필요한 카운트 쿼리가 날라와서 지워버렸습니다
- 웹소켓 세션 애트리뷰트에 입장했을때만 데이터를 저장하고, 메시지 보낼때는 저장안했더니 재접속한 후 세션이 끊어지면 에러가 나길래 고쳤습니당

## 🔎 추가 정보
- #113 