### PR TITLE
:recycle: 팟 조회시 사용자와 팟과의 관계 추가

### DIFF
--- a/src/main/java/com/tickettogether/domain/member/domain/Role.java
+++ b/src/main/java/com/tickettogether/domain/member/domain/Role.java
@@ -12,8 +12,10 @@ public enum Role {
     GUEST("ROLE_GUEST", "손님"),     //최초 가입
     ADMIN("ROLE_ADMIN", "관리자"),
     USER("ROLE_USER", "일반 사용자"),
-    MANAGER("ROLE_MANAGER", "팟 만든 사람"),
-    MEMBER("ROLE_MEMBER", "팟 참여자");
+
+    PART_MANAGER("PART_MANAGER", "방장"),  // 팟 관련 role
+    PART_MEMBER("PART_MEMBER", "팟 멤버"),
+    PART_USER("PART_UNRELATED", "팟에 참여되지 않은 사용자");
 
     private final String key;
     private final String title;

--- a/src/main/java/com/tickettogether/domain/parts/controller/PartsController.java
+++ b/src/main/java/com/tickettogether/domain/parts/controller/PartsController.java
@@ -16,7 +16,7 @@ import static com.tickettogether.domain.parts.dto.PartsResponseMessage.*;
 public class PartsController {
     private final MemberPartsService partsService;
 
-    private final Long tempMemberId = 1L;
+    private final Long tempMemberId = 6L;
 
     @ApiOperation(value = "팟 생성", notes = "요청한 멤버가 방장으로, 팟을 생성한다.")
     @PostMapping("/{prodId}")
@@ -27,7 +27,7 @@ public class PartsController {
     @ApiOperation(value = "팟 조회", notes = "공연 정보에 맞는 팟을 조회한다.")
     @GetMapping("/{prodId}")
     public ResponseEntity<BaseResponse<List<PartsDto.SearchResponse>>> getParts(@PathVariable("prodId") Long prodId) {
-        return ResponseEntity.ok(BaseResponse.create(GET_PARTS_SUCCESS.getMessage(),partsService.searchParts(prodId)));
+        return ResponseEntity.ok(BaseResponse.create(GET_PARTS_SUCCESS.getMessage(),partsService.searchParts(tempMemberId, prodId)));
     }
 
     @ApiOperation(value = "팟 참여", notes = "사용자가 원하는 팟에 참여한다.")

--- a/src/main/java/com/tickettogether/domain/parts/controller/PartsController.java
+++ b/src/main/java/com/tickettogether/domain/parts/controller/PartsController.java
@@ -16,7 +16,7 @@ import static com.tickettogether.domain.parts.dto.PartsResponseMessage.*;
 public class PartsController {
     private final MemberPartsService partsService;
 
-    private final Long tempMemberId = 6L;
+    private final Long tempMemberId = 1L;
 
     @ApiOperation(value = "팟 생성", notes = "요청한 멤버가 방장으로, 팟을 생성한다.")
     @PostMapping("/{prodId}")

--- a/src/main/java/com/tickettogether/domain/parts/dto/PartsDto.java
+++ b/src/main/java/com/tickettogether/domain/parts/dto/PartsDto.java
@@ -1,5 +1,6 @@
 package com.tickettogether.domain.parts.dto;
 
+import com.tickettogether.domain.member.domain.Role;
 import com.tickettogether.domain.parts.domain.MemberParts;
 import com.tickettogether.domain.parts.domain.Parts;
 import lombok.*;
@@ -56,7 +57,7 @@ public class PartsDto {
         private int partTotal;
         private int currentPartTotal;
         private Parts.Status status;
-        private memberRole role;
+        private Role role;
 
     }
 
@@ -84,18 +85,6 @@ public class PartsDto {
 
     }
 
-    @Getter
-    @RequiredArgsConstructor
-    public enum memberRole{
-
-        MANAGER("ROLE_MANAGER", "방장"),
-        MEMBER("ROLE_MEMBER", "팟 멤버"),
-        USER("ROLE_USER", "팟에 참여되지 않은 사용자");
-
-        private final String companyCode;
-        private final String viewName;
-
-    }
 
 }
 

--- a/src/main/java/com/tickettogether/domain/parts/dto/PartsDto.java
+++ b/src/main/java/com/tickettogether/domain/parts/dto/PartsDto.java
@@ -1,6 +1,5 @@
 package com.tickettogether.domain.parts.dto;
 
-import com.tickettogether.domain.member.domain.Member;
 import com.tickettogether.domain.parts.domain.MemberParts;
 import com.tickettogether.domain.parts.domain.Parts;
 import lombok.*;
@@ -57,18 +56,8 @@ public class PartsDto {
         private int partTotal;
         private int currentPartTotal;
         private Parts.Status status;
+        private memberRole role;
 
-        public SearchResponse(Parts parts) {
-            this.managerId = parts.getManager().getId();
-            this.cultureName = parts.getCulture().getName();
-            this.partId = parts.getId();
-            this.partName = parts.getPartName();
-            this.partContent =  parts.getPartContent();
-            this.partDate = parts.getPartDate();
-            this.partTotal = parts.getPartTotal();
-            this.currentPartTotal = parts.getCurrentPartTotal();
-            this.status = parts.getStatus();
-        }
     }
 
     @Getter
@@ -92,6 +81,19 @@ public class PartsDto {
         private String memberName;
         private String memberImgUrl;
         private boolean isManager;
+
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum memberRole{
+
+        MANAGER("ROLE_MANAGER", "방장"),
+        MEMBER("ROLE_MEMBER", "팟 멤버"),
+        USER("ROLE_USER", "팟에 참여되지 않은 사용자");
+
+        private final String companyCode;
+        private final String viewName;
 
     }
 

--- a/src/main/java/com/tickettogether/domain/parts/service/MemberPartsService.java
+++ b/src/main/java/com/tickettogether/domain/parts/service/MemberPartsService.java
@@ -7,7 +7,7 @@ import java.util.List;
 @Service
 public interface MemberPartsService {
     PartsDto.CreateResponse createParts(Long userId, Long prodId, PartsDto.CreateRequest requestDto);
-    List<PartsDto.SearchResponse> searchParts(Long prodId);
+    List<PartsDto.SearchResponse> searchParts(Long userId, Long prodId);
     void joinParts(Long userId, Long partId);
     PartsDto.closeResponse closeParts(Long userId, Long partId);
     void deleteParts(Long userId, Long partId);

--- a/src/main/java/com/tickettogether/domain/parts/service/MemberPartsServiceImpl.java
+++ b/src/main/java/com/tickettogether/domain/parts/service/MemberPartsServiceImpl.java
@@ -4,6 +4,7 @@ import com.tickettogether.domain.culture.domain.Culture;
 import com.tickettogether.domain.culture.exception.CultureEmptyException;
 import com.tickettogether.domain.culture.repository.CultureRepository;
 import com.tickettogether.domain.member.domain.Member;
+import com.tickettogether.domain.member.domain.Role;
 import com.tickettogether.domain.member.exception.UserEmptyException;
 import com.tickettogether.domain.member.repository.MemberRepository;
 import com.tickettogether.domain.parts.domain.MemberParts;
@@ -183,15 +184,15 @@ public class MemberPartsServiceImpl implements MemberPartsService {
         return false;
     }
 
-    private PartsDto.memberRole getMemberRole(Member user, Parts parts) {
+    private Role getMemberRole(Member user, Parts parts) {
         if (parts.getManager().equals(user)) {
-            return PartsDto.memberRole.MANAGER;
+            return Role.PART_MANAGER;
         }
         else if (checkParticipation(user, parts.getMemberParts())){
-            return PartsDto.memberRole.MEMBER;
+            return Role.PART_MEMBER;
         }
         else
-            return PartsDto.memberRole.USER;
+            return Role.PART_USER;
     }
 
     private PartsDto.SearchResponse createSearchResponse(Member user, Parts parts){

--- a/src/main/java/com/tickettogether/global/error/handler/RestControllerExceptionHandler.java
+++ b/src/main/java/com/tickettogether/global/error/handler/RestControllerExceptionHandler.java
@@ -84,7 +84,7 @@ public class RestControllerExceptionHandler {
      */
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> handleException(Exception ex) {
-        log.error("handleEntityNotFoundException: {}", ex.getMessage());
+        ex.printStackTrace();
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ErrorResponse.create(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 }


### PR DESCRIPTION
## ☁️ 개요
- #140

## ✏️ 작업 내용
- 팟을 만든 방장: MANAGER
- 팟에 참여한 사용자: MEMBER
- 팟에 참여하지 않은 사용자: USER

다음과 같이 사용자와 팟과의 관계를 3가지로 설정하여 팟 조회시 볼 수 있도록 추가 하였습니다.

## 🔎 추가 정보

- 프론트에서 작업하기 쉽도록 리팩토링했습니당