### PR TITLE
♻️ 팟 삭제시 예외처리 추가

### DIFF
--- a/src/main/java/com/tickettogether/domain/parts/controller/PartsController.java
+++ b/src/main/java/com/tickettogether/domain/parts/controller/PartsController.java
@@ -15,7 +15,7 @@ import static com.tickettogether.domain.parts.dto.PartsResponseMessage.*;
 @RequestMapping("/api/v1/parts")
 public class PartsController {
     private final MemberPartsService partsService;
-    private final Long tempMemberId = 1L;
+    private final Long tempMemberId = 3L;
 
     @ApiOperation(value = "팟 생성", notes = "요청한 멤버가 방장으로, 팟을 생성한다.")
     @PostMapping("/{prodId}")

--- a/src/main/java/com/tickettogether/domain/parts/controller/PartsController.java
+++ b/src/main/java/com/tickettogether/domain/parts/controller/PartsController.java
@@ -15,7 +15,7 @@ import static com.tickettogether.domain.parts.dto.PartsResponseMessage.*;
 @RequestMapping("/api/v1/parts")
 public class PartsController {
     private final MemberPartsService partsService;
-    private final Long tempMemberId = 3L;
+    private final Long tempMemberId = 1L;
 
     @ApiOperation(value = "팟 생성", notes = "요청한 멤버가 방장으로, 팟을 생성한다.")
     @PostMapping("/{prodId}")

--- a/src/main/java/com/tickettogether/domain/parts/exception/PartsMemberExistedException.java
+++ b/src/main/java/com/tickettogether/domain/parts/exception/PartsMemberExistedException.java
@@ -1,0 +1,10 @@
+package com.tickettogether.domain.parts.exception;
+
+import com.tickettogether.global.error.ErrorCode;
+import com.tickettogether.global.error.exception.BusinessException;
+
+public class PartsMemberExistedException extends BusinessException {
+    public PartsMemberExistedException() {
+        super(ErrorCode.PARTS_MEMBER_EXISTED);
+    }
+}

--- a/src/main/java/com/tickettogether/domain/parts/service/MemberPartsServiceImpl.java
+++ b/src/main/java/com/tickettogether/domain/parts/service/MemberPartsServiceImpl.java
@@ -148,6 +148,11 @@ public class MemberPartsServiceImpl implements MemberPartsService {
         if (!parts.getManager().equals(user)) {
             throw new PartsDeleteDeniedException();
         }
+
+        if (parts.getCurrentPartTotal() > 1) {
+            throw new PartsMemberExistedException();
+        }
+
         partsRepository.deleteById(partId);
 
     }

--- a/src/main/java/com/tickettogether/global/error/ErrorCode.java
+++ b/src/main/java/com/tickettogether/global/error/ErrorCode.java
@@ -68,6 +68,7 @@ public enum ErrorCode {
     PARTS_FULL(3044, "해당 팟의 인원이 모두 찼습니다."),
     PARTS_LEAVE_DENIED(3045, "해당 팟에서 나갈 권한이 없습니다."),
     PARTS_CLOSED(3046, "해당 팟은 이미 마감되었습니다."),
+    PARTS_MEMBER_EXISTED(3047, "해당 팟에 멤버가 존재하여 삭제할 수 없습니다."),
 
 
     /**


### PR DESCRIPTION
## ☁️ 개요
- #172

## ✏️ 작업 내용
- 팟 삭제시 방장 이외에 해당 팟에 참여한 멤버가 있으면 삭제가 불가능하도록 예외처리

## 🔎 추가 정보
