### PR TITLE
:sparkles: 팟 status 기준 정렬 기능 추가 

### DIFF
--- a/src/main/java/com/tickettogether/domain/parts/repository/PartsRepository.java
+++ b/src/main/java/com/tickettogether/domain/parts/repository/PartsRepository.java
@@ -2,10 +2,12 @@ package com.tickettogether.domain.parts.repository;
 
 import com.tickettogether.domain.culture.domain.Culture;
 import com.tickettogether.domain.parts.domain.Parts;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface PartsRepository extends JpaRepository<Parts, Long>{
-    List<Parts> findByCultureOrderByPartDate(Culture culture);
+
+    List<Parts> findByCulture(Culture culture, Sort sort);
 }

--- a/src/main/java/com/tickettogether/domain/parts/service/MemberPartsServiceImpl.java
+++ b/src/main/java/com/tickettogether/domain/parts/service/MemberPartsServiceImpl.java
@@ -15,6 +15,7 @@ import com.tickettogether.domain.parts.repository.MemberPartsRepository;
 import com.tickettogether.domain.parts.repository.PartsRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
@@ -63,7 +64,9 @@ public class MemberPartsServiceImpl implements MemberPartsService {
         Member user = findMemberById(userId);
         Culture culture = findCultureById(prodId);
 
-        List<Parts> partsList = partsRepository.findByCultureOrderByPartDate(culture);
+        Sort sort = Sort.by(Sort.Direction.ASC, "status", "partDate");
+        List<Parts> partsList = partsRepository.findByCulture(culture, sort);
+
         List<PartsDto.SearchResponse> partsInfoList = new ArrayList<>();
 
         for (Parts parts : partsList) {


### PR DESCRIPTION
## ☁️ 개요
- #184 

## ✏️ 작업 내용
- ACTIVE인 팟이 우선 정렬되도록 기능 추가하였습니다.

## 🔎 추가 정보
